### PR TITLE
apt_repository force codename

### DIFF
--- a/tasks/debian.yaml
+++ b/tasks/debian.yaml
@@ -2,6 +2,9 @@
 
 - name: system packages | setup nginx ppa repo
   apt_repository:
+    # This shouldn't be necessary but in some cases Ansible gets the wrong name
+    # https://github.com/ansible/ansible/issues/45614
+    codename: "{{ ansible_distribution_release }}"
     repo: ppa:nginx/{{ nginx_stable_repo | ternary('stable', 'mainline') }}
 
 - name: system packages | install nginx


### PR DESCRIPTION
This shouldn't be necessary according to the docs:
https://docs.ansible.com/ansible/latest/modules/apt_repository_module.html

But sometimes after installing another package this stops working. Possible Ansible bug? https://github.com/ansible/ansible/issues/45614

Tag: bugfix, `2.0.1`