### PR TITLE
Molecule tests: fix Nginx version test on CentOS 7

### DIFF
--- a/molecule/centos7/tests/test_default.py
+++ b/molecule/centos7/tests/test_default.py
@@ -45,4 +45,4 @@ def test_version(host):
     if hostname == 'nginx-custom':
         assert ver == ('nginx version: nginx/1.15.8')
     else:
-        assert ver.startswith('nginx version: nginx/1.16.')
+        assert ver.startswith('nginx version: nginx/1.18.')


### PR DESCRIPTION
The stable packages are now pulling Nginx 1.18 - noticed via https://travis-ci.org/github/ome/ansible-roles/builds/681808514