### PR TITLE
Configure whether nginx is restarted with systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Role Variables
 - `nginx_keep_default_configs`: If `true` keep the default site configuration files in `nginx/conf.d`, default `false` (disable them)
 - `nginx_stable_repo`: If `false` use the mainline instead of stable repo, default `true`
 - `nginx_version`: The packaged version of Nginx, optional, available versions depends on `nginx_stable_repo`. Not supported on Ubuntu.
+- `nginx_systemd_setup`: Start/restart nginx using systemd, default `true`
+, if you want to manage Nginx yourself set this to `false`
 
 Log rotation:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,6 @@ nginx_stable_repo: true
 
 # Keep default configurations under /etc/nginx
 nginx_keep_default_configs: false
+
+# Start/restart nginx using systemd
+nginx_systemd_setup: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,4 @@
   service:
     name: nginx
     state: restarted
+  when: nginx_systemd_setup

--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -7,13 +7,15 @@ lint:
   name: yamllint
 platforms:
   - name: nginx-default
-    image: centos/systemd
-    image_version: latest
+    image: centos/systemd:latest
     command: /sbin/init
     privileged: true
   - name: nginx-custom
-    image: centos/systemd
-    image_version: latest
+    image: centos/systemd:latest
+    command: /sbin/init
+    privileged: true
+  - name: nginx-disabled
+    image: centos/systemd:latest
     command: /sbin/init
     privileged: true
 provisioner:
@@ -31,6 +33,8 @@ provisioner:
         nginx_version: 1.15.8
         nginx_logrotate_interval: weekly
         nginx_logrotate_backlog_size: 5
+      nginx-disabled:
+        nginx_systemd_setup: false
 scenario:
   name: centos7
 verifier:

--- a/molecule/centos7/tests/test_default.py
+++ b/molecule/centos7/tests/test_default.py
@@ -12,8 +12,10 @@ def test_package(host):
 
 def test_service(host):
     hostname = host.backend.get_hostname()
-    if hostname != 'nginx-custom':
-        service = host.service('nginx')
+    service = host.service('nginx')
+    if hostname == 'nginx-disabled':
+        assert not service.is_running
+    else:
         assert service.is_running
 
 

--- a/molecule/ubuntu1804/molecule.yml
+++ b/molecule/ubuntu1804/molecule.yml
@@ -18,6 +18,12 @@ platforms:
     privileged: true
     tmpfs:
       - /sys/fs/cgroup
+  - name: nginx-disabled
+    image: leandelivery/docker-systemd:ubuntu-18.04
+    command: /sbin/init
+    privileged: true
+    tmpfs:
+      - /sys/fs/cgroup
 provisioner:
   name: ansible
   inventory:
@@ -27,6 +33,8 @@ provisioner:
         nginx_stable_repo: false
         nginx_logrotate_interval: weekly
         nginx_logrotate_backlog_size: 5
+      nginx-disabled:
+        nginx_systemd_setup: false
   playbooks:
     converge: ../resources/playbook.yml
   lint:

--- a/molecule/ubuntu1804/tests/test_default.py
+++ b/molecule/ubuntu1804/tests/test_default.py
@@ -11,8 +11,10 @@ def test_package(host):
 
 def test_service(host):
     hostname = host.backend.get_hostname()
-    if hostname != 'nginx-custom':
-        service = host.service('nginx')
+    service = host.service('nginx')
+    if hostname == 'nginx-disabled':
+        assert not service.is_running
+    else:
         assert service.is_running
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
   service:
     name: nginx
     state: started
+  when: nginx_systemd_setup
 
 - name: nginx | configure logrotate
   become: true


### PR DESCRIPTION
This can be used when you want to manage the running of Nginx yourself

Tag: new feature, `2.1.0`