### PR TITLE
Disable EPEL repository when installing NGINX

### DIFF
--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -22,6 +22,7 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../resources/playbook.yml
+    prepare: prepare.yml
   lint:
     name: ansible-lint
   inventory:

--- a/molecule/centos7/prepare.yml
+++ b/molecule/centos7/prepare.yml
@@ -1,0 +1,8 @@
+---
+- hosts: nginx-disabled
+  tasks:
+  - name: Install epel
+    become: true
+    yum:
+      name: epel-release
+      state: present

--- a/molecule/centos7/tests/test_default.py
+++ b/molecule/centos7/tests/test_default.py
@@ -47,4 +47,4 @@ def test_version(host):
     if hostname == 'nginx-custom':
         assert ver == ('nginx version: nginx/1.15.8')
     else:
-        assert ver.startswith('nginx version: nginx/1.18.')
+        assert ver.startswith('nginx version: nginx/1.20.1')

--- a/molecule/centos7/tests/test_default.py
+++ b/molecule/centos7/tests/test_default.py
@@ -48,3 +48,9 @@ def test_version(host):
         assert ver == ('nginx version: nginx/1.15.8')
     else:
         assert ver.startswith('nginx version: nginx/1.20.1')
+
+
+def test_nginx_configuration(host):
+    c = host.file('/etc/nginx/nginx.conf')
+    assert 'http {' in c.content_string
+    assert 'server {' not in c.content_string

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -23,6 +23,7 @@
       nginx{{ (nginx_version | length > 0) |
         ternary('-' + nginx_version, '') }}
     state: present
+    disablerepo: epel
 
 # example_ssl.conf is in some distro versions but not upstream, disable it
 # just in case

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -16,6 +16,11 @@
     mode: 0644
   when: not nginx_stable_repo
 
+- name: system packages | check if epel is installed
+  stat:
+    path: '/etc/yum.repos.d/epel.repo'
+  register: epel_repo
+
 - name: system packages | install nginx
   become: true
   yum:
@@ -23,7 +28,7 @@
       nginx{{ (nginx_version | length > 0) |
         ternary('-' + nginx_version, '') }}
     state: present
-    disablerepo: epel
+    disablerepo: "{{ epel_repo.stat.exists | ternary('epel', '') }}"
 
 # example_ssl.conf is in some distro versions but not upstream, disable it
 # just in case


### PR DESCRIPTION
Recent patch releases of nginx show difference in the default configuration folder between NGINX and EPEL repositories
Since the previous task deal with the installation of the stable NGINX repository, this ensures this repository is used.

This is a similar issue to the one dealt with in https://github.com/ome/devspace/pull/183. In the case of our Ansible playbooks, this was discovered in the context of a pilot IDR server with Nginx 1.20.1-2el7 always serving the default page. The content of `/etc/nginx/nginx.conf` shipped by the EPEL rpm now includes a default `server` section and no longer works out-of-the box with the nginx configuration created by https://github.com/ome/ansible-role-omero-web/blob/d6fa479790aa272f8ebca048dfaf3ba4cca4a07e/tasks/web-nginx.yml#L20-L26. This does not affect advanced playbooks e.g. using `ome.nginx_proxy` or manually overwriting `nginx.conf`

This PR makes the minimal change to ensure the existing playbooks keep working as expected.

Proposed tag: `2.1.2`