### PR TITLE
Disablerepo epel test

### DIFF
--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -22,6 +22,7 @@ provisioner:
   name: ansible
   playbooks:
     converge: ../resources/playbook.yml
+    prepare: prepare.yml
   lint:
     name: ansible-lint
   inventory:

--- a/molecule/centos7/prepare.yml
+++ b/molecule/centos7/prepare.yml
@@ -1,0 +1,8 @@
+---
+- hosts: nginx-disabled
+  tasks:
+  - name: Install epel
+    become: true
+    yum:
+      name: epel-release
+      state: present

--- a/molecule/centos7/tests/test_default.py
+++ b/molecule/centos7/tests/test_default.py
@@ -47,4 +47,4 @@ def test_version(host):
     if hostname == 'nginx-custom':
         assert ver == ('nginx version: nginx/1.15.8')
     else:
-        assert ver.startswith('nginx version: nginx/1.18.')
+        assert ver.startswith('nginx version: nginx/1.20.1')

--- a/molecule/centos7/tests/test_default.py
+++ b/molecule/centos7/tests/test_default.py
@@ -48,3 +48,9 @@ def test_version(host):
         assert ver == ('nginx version: nginx/1.15.8')
     else:
         assert ver.startswith('nginx version: nginx/1.20.1')
+
+
+def test_nginx_configuration(host):
+    c = host.file('/etc/nginx/nginx.conf')
+    assert 'http {' in c.content_string
+    assert 'server {' not in c.content_string


### PR DESCRIPTION
This temporary PR aims at demonstrating the nginx/epel issue with the default `nginx.conf`.

On CentOS 7, nginx 1.20.1 is now shipped via both the Nginx & EPEL repositories but the second includes significant changes to the `nginx.conf` including a default `server` configuration.

The new test introduced in 67c5545  should fail in the case where `epel-release` is installed

