### PR TITLE
Become root

### DIFF
--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -1,5 +1,6 @@
 ---
 - name: Import a key for nginx
+  become: true
   ansible.builtin.rpm_key:
     state: present
     key:  https://nginx.org/keys/nginx_signing.key


### PR DESCRIPTION
When running the playbook to create a rocky9 pilot, I got:
```
TASK [ome.nginx : Import a key for nginx] ******************************************************************************************************************************************
fatal: [2f5d1f82-2aad-433b-ab9f-98c5fe25ffa5]: FAILED! => {"changed": false, "msg": "error: can't create transaction lock on /var/lib/rpm/.rpm.lock (Permission denied)\nerror: /tmp/tmp31_1w5ho: key 1 import failed.\n"}
```

This PR fixes the issue.

~~**Note:** There's still the issue that selinux prevents nginx from serving omero.web. As a workaround I manually set `SELINUX=disabled` in `/etc/selinux/config` (and `setenforce 0` in order to not have to reboot). Don't know how/if this could be added to the role.~~ (now handled in https://github.com/ome/ansible-role-omero-web/pull/50 )
