### PR TITLE
Adjust nginx repo and default version

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install Ansible & Molecule
         run: |
             pip install "ansible<8" "ansible-lint<6.13" flake8

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -53,4 +53,3 @@ jobs:
         with:
           galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}
           galaxy_version: ${{  github.ref_name }}
-

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   list-scenarios:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.listscenarios.outputs.scenarios }}
     steps:
@@ -22,7 +22,7 @@ jobs:
     name: Test
     needs:
       - list-scenarios
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false
@@ -32,11 +32,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install Ansible & Molecule
         run: |
-            pip install "ansible<8" "ansible-lint<6.13" flake8
-            pip install "molecule<5" "ansible-compat<4"
+            pip install "requests" "ansible" "ansible-lint" "flake8"
+            pip install "molecule" "ansible-compat"
             pip install molecule-plugins[docker] pytest-testinfra
       - name: Run molecule
         run: molecule test -s "${{ matrix.scenario }}"
@@ -46,7 +46,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: galaxy
         uses: ansible-actions/ansible-galaxy-action@v1.2.0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Role Variables
 - `nginx_version`: The packaged version of Nginx, optional, available versions depends on `nginx_stable_repo`. Not supported on Ubuntu.
 - `nginx_systemd_setup`: Start/restart nginx using systemd, default `true`
 , if you want to manage Nginx yourself set this to `false`
-
+- `nginx_remove`: Remove Nginx, default is `false`
 Log rotation:
 
 - `nginx_logrotate_interval`: Rotate log files at this interval, default `daily`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,6 @@ nginx_keep_default_configs: false
 
 # Start/restart nginx using systemd
 nginx_systemd_setup: true
+
+# Remove nginx first
+nginx_remove: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install upstream Nginx
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.6
+  min_ansible_version: 2.11
   platforms:
     - name: EL
       versions:

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -48,7 +48,7 @@ provisioner:
         nginx_keep_default_configs: true
         nginx_stable_repo: false
         # Current mainline is 1.15.9
-        nginx_version: 1.20.2
+        nginx_version: 1.26.2
         nginx_logrotate_interval: weekly
         nginx_logrotate_backlog_size: 5
       nginx-disabled:

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -34,7 +34,7 @@ platforms:
     tmpfs:
       - /sys/fs/cgroup
     groups:
-        - extra_options
+      - extra_options
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -48,7 +48,7 @@ provisioner:
         nginx_keep_default_configs: true
         nginx_stable_repo: false
         # Current mainline is 1.15.9
-        nginx_version: 1.26.2
+        nginx_version: 1.29.1
         nginx_logrotate_interval: weekly
         nginx_logrotate_backlog_size: 5
       nginx-disabled:

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -47,8 +47,7 @@ provisioner:
       nginx-custom:
         nginx_keep_default_configs: true
         nginx_stable_repo: false
-        # Current mainline is 1.15.9
-        nginx_version: 1.29.1
+        nginx_version: 1.28.0
         nginx_logrotate_interval: weekly
         nginx_logrotate_backlog_size: 5
       nginx-disabled:

--- a/molecule/rockylinux9/tests/test_default.py
+++ b/molecule/rockylinux9/tests/test_default.py
@@ -47,7 +47,7 @@ def test_version(host):
     if hostname == 'nginx-custom':
         assert ver == ('nginx version: nginx/1.26.2')
     else:
-        assert ver.startswith('nginx version: nginx/1.26.0')
+        assert ver.startswith('nginx version: nginx/1.26.2')
 
 
 def test_nginx_configuration(host):

--- a/molecule/rockylinux9/tests/test_default.py
+++ b/molecule/rockylinux9/tests/test_default.py
@@ -45,9 +45,9 @@ def test_version(host):
     assert r.rc == 0
     ver = r.stderr.strip()
     if hostname == 'nginx-custom':
-        assert ver == ('nginx version: nginx/1.20.2')
+        assert ver == ('nginx version: nginx/1.26.2')
     else:
-        assert ver.startswith('nginx version: nginx/1.24.0')
+        assert ver.startswith('nginx version: nginx/1.26.0')
 
 
 def test_nginx_configuration(host):

--- a/molecule/rockylinux9/tests/test_default.py
+++ b/molecule/rockylinux9/tests/test_default.py
@@ -45,7 +45,7 @@ def test_version(host):
     assert r.rc == 0
     ver = r.stderr.strip()
     if hostname == 'nginx-custom':
-        assert ver == ('nginx version: nginx/1.26.2')
+        assert ver == ('nginx version: nginx/1.29.1')
     else:
         assert ver.startswith('nginx version: nginx/1.26.2')
 

--- a/molecule/rockylinux9/tests/test_default.py
+++ b/molecule/rockylinux9/tests/test_default.py
@@ -47,7 +47,7 @@ def test_version(host):
     if hostname == 'nginx-custom':
         assert ver == ('nginx version: nginx/1.29.1')
     else:
-        assert ver.startswith('nginx version: nginx/1.26.2')
+        assert ver.startswith('nginx version: nginx/1.29.1')
 
 
 def test_nginx_configuration(host):

--- a/molecule/rockylinux9/tests/test_default.py
+++ b/molecule/rockylinux9/tests/test_default.py
@@ -45,9 +45,9 @@ def test_version(host):
     assert r.rc == 0
     ver = r.stderr.strip()
     if hostname == 'nginx-custom':
-        assert ver == ('nginx version: nginx/1.29.1')
+        assert ver == ('nginx version: nginx/1.28.0')
     else:
-        assert ver.startswith('nginx version: nginx/1.29.1')
+        assert ver.startswith('nginx version: nginx/1.28.0')
 
 
 def test_nginx_configuration(host):

--- a/tasks/debian.yaml
+++ b/tasks/debian.yaml
@@ -1,4 +1,11 @@
 ---
+- name: system packages | remove nginx
+  become: true
+  ansible.builtin.apt:
+    name: nginx
+    state: absent
+  when: nginx_remove
+
 - name: system packages | install nginx
   become: true
   ansible.builtin.apt:

--- a/tasks/debian.yaml
+++ b/tasks/debian.yaml
@@ -1,17 +1,4 @@
 ---
-# - name: system packages | add nginx apt key
-#   become: true
-#   ansible.builtin.apt_key:
-#     keyring: /usr/share/keyrings/nginx-archive-keyring.gpg
-#     url:  https://nginx.org/keys/nginx_signing.key
-#     id: ABF5BD827BD9BF62
-
-
-# - name: system packages | Add nginx stable repository into sources list
-#   ansible.builtin.apt_repository:
-#     repo: "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/ubuntu jammy nginx"
-#     state: present
-
 - name: system packages | install nginx
   become: true
   ansible.builtin.apt:
@@ -21,6 +8,6 @@
 
 - name: nginx | remove default config
   become: true
-  file:
+  ansible.builtin.file:
     path: /etc/nginx/sites-enabled/default
     state: absent

--- a/tasks/debian.yaml
+++ b/tasks/debian.yaml
@@ -2,6 +2,8 @@
 - name: system packages | remove nginx
   become: true
   ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 86400
     name: nginx
     state: absent
   when: nginx_remove
@@ -10,6 +12,7 @@
   become: true
   ansible.builtin.apt:
     update_cache: true
+    cache_valid_time: 86400
     name: nginx
     state: present
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: nginx | configure logrotate
   become: true
-  template:
+  ansible.builtin.template:
     backup: false
     dest: /etc/logrotate.d/nginx
     src: logrotated-nginx.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 # tasks file for roles/nginx
 
-- import_tasks: redhat.yaml
+- ansible.builtin.import_tasks: redhat.yaml
   when: ansible_os_family | lower == 'redhat'
 
-- import_tasks: debian.yaml
+- ansible.builtin.import_tasks: debian.yaml
   when: ansible_os_family | lower == 'debian'
 
 - name: nginx | running
   become: true
-  service:
+  ansible.builtin.service:
     name: nginx
     state: started
   when: nginx_systemd_setup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - ansible.builtin.import_tasks: redhat.yaml
   when: ansible_os_family | lower == 'redhat'
 
-- ansible.builtin.import_tasks: debian.yaml
+- ansible.builtin.include_tasks: debian.yaml
   when: ansible_os_family | lower == 'debian'
 
 - name: nginx | running

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for roles/nginx
 
-- ansible.builtin.import_tasks: redhat.yaml
+- ansible.builtin.include_tasks: redhat.yaml
   when: ansible_os_family | lower == 'redhat'
 
 - ansible.builtin.include_tasks: debian.yaml

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -9,7 +9,7 @@
   become: true
   ansible.builtin.dnf:
     update_cache: true
-    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-1.24.0-1.el9.ngx.x86_64.rpm"
+    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-1.26.2-2.el9.ngx.x86_64.rpm"
     state: present
   when: not nginx_version
 

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -35,7 +35,7 @@
 # just in case
 - name: nginx | remove default config
   become: true
-  copy:
+  ansible.builtin.copy:
     content: "# This file is intentionally blank (Ansible)"
     dest: /etc/nginx/conf.d/{{ item }}
     mode: 0644

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -3,13 +3,14 @@
   become: true
   ansible.builtin.rpm_key:
     state: present
-    key:  https://nginx.org/keys/nginx_signing.key
+    key: https://nginx.org/keys/nginx_signing.key
 
 - name: system packages | setup upstream nginx stable repo
   become: true
   ansible.builtin.dnf:
     update_cache: true
-    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-1.26.2-2.el9.ngx.x86_64.rpm"
+    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/\
+           nginx-1.26.2-2.el9.ngx.x86_64.rpm"
     state: present
   when: not nginx_version
 
@@ -17,7 +18,8 @@
   become: true
   ansible.builtin.dnf:
     update_cache: true
-    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
+    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/\
+           nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
     state: present
   when: nginx_version
 

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -23,6 +23,14 @@
     state: present
   when: nginx_version
 
+- name: system packages | remove nginx
+  become: true
+  ansible.builtin.dnf:
+    name: >-
+      nginx
+    state: absent
+  when: nginx_remove
+
 - name: system packages | install nginx
   become: true
   ansible.builtin.dnf:

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -9,7 +9,7 @@
   become: true
   ansible.builtin.dnf:
     update_cache: true
-    name: "https://nginx.org/packages/mainline/centos/9/x86_64/RPMS/nginx-1.29.1-1.el9.ngx.x86_64.rpm"
+    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-1.28.0-1.el9.ngx.x86_64.rpm"
     state: present
   when: nginx_version | length == 0
 
@@ -17,7 +17,7 @@
   become: true
   ansible.builtin.dnf:
     update_cache: true
-    name: "https://nginx.org/packages/mainline/centos/9/x86_64/RPMS/nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
+    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
     state: present
   when: nginx_version | length >  0
 

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -9,8 +9,7 @@
   become: true
   ansible.builtin.dnf:
     update_cache: true
-    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/\
-           nginx-1.26.2-2.el9.ngx.x86_64.rpm"
+    name: "https://nginx.org/packages/mainline/centos/9/x86_64/RPMS/nginx-1.29.1-1.el9.ngx.x86_64.rpm"
     state: present
   when: not nginx_version
 
@@ -18,8 +17,7 @@
   become: true
   ansible.builtin.dnf:
     update_cache: true
-    name: "https://nginx.org/packages/centos/9/x86_64/RPMS/\
-           nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
+    name: "https://nginx.org/packages/mainline/centos/9/x86_64/RPMS/nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
     state: present
   when: nginx_version
 

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -11,7 +11,7 @@
     update_cache: true
     name: "https://nginx.org/packages/mainline/centos/9/x86_64/RPMS/nginx-1.29.1-1.el9.ngx.x86_64.rpm"
     state: present
-  when: not nginx_version
+  when: nginx_version == ""
 
 - name: system packages | setup upstream nginx stable repo
   become: true
@@ -19,7 +19,7 @@
     update_cache: true
     name: "https://nginx.org/packages/mainline/centos/9/x86_64/RPMS/nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
     state: present
-  when: nginx_version
+  when: nginx_version != ""
 
 - name: system packages | remove nginx
   become: true

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -19,7 +19,7 @@
     update_cache: true
     name: "https://nginx.org/packages/mainline/centos/9/x86_64/RPMS/nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
     state: present
-  when: nginx_version != ""
+  when: nginx_version | length >  0
 
 - name: system packages | remove nginx
   become: true

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -21,6 +21,8 @@
     state: present
   when: nginx_version | length >  0
 
+# Sometimes necessary to override the nginx
+# by default by the OS
 - name: system packages | remove nginx
   become: true
   ansible.builtin.dnf:

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -8,7 +8,6 @@
 - name: system packages | setup upstream nginx stable repo
   become: true
   ansible.builtin.dnf:
-    update_cache: true
     name: "https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-1.28.0-1.el9.ngx.x86_64.rpm"
     state: present
   when: nginx_version | length == 0
@@ -16,7 +15,6 @@
 - name: system packages | setup upstream nginx stable repo
   become: true
   ansible.builtin.dnf:
-    update_cache: true
     name: "https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
     state: present
   when: nginx_version | length >  0
@@ -34,7 +32,6 @@
 - name: system packages | install nginx
   become: true
   ansible.builtin.dnf:
-    update_cache: true
     name: >-
       nginx
     state: present

--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -11,7 +11,7 @@
     update_cache: true
     name: "https://nginx.org/packages/mainline/centos/9/x86_64/RPMS/nginx-1.29.1-1.el9.ngx.x86_64.rpm"
     state: present
-  when: nginx_version == ""
+  when: nginx_version | length == 0
 
 - name: system packages | setup upstream nginx stable repo
   become: true


### PR DESCRIPTION
This is on top of https://github.com/ome/ansible-role-nginx/pull/16

Recently we were asked to upgrade to nginx 1.29.1. 

On https://nginx.org/packages/centos/9/x86_64/RPMS/ there is no package  >1.28.x, so this role was failing to upgrade the nginx on RHEL 9.

But on https://nginx.org/packages/mainline/centos/9/x86_64/RPMS/ there is 1.29.x available.

Updating the role accordingly.
Also bumping the default version (when the nginx_version variable is NOT set) to 1.29.1.

Note: https://github.com/ome/ansible-role-nginx/pull/17/commits/2ff1de65c0124812bee8babe8d52d7c3553b8c15 is necessary because the rules on conditionals are stricter now, the tests started to fail even on this PR - the https://github.com/ome/ansible-role-nginx/pull/17/commits/2ff1de65c0124812bee8babe8d52d7c3553b8c15 is fixing it.

This was tested together with https://github.com/ome/ansible-role-omero-web/pull/54 on:

```
TASK [omero-web | Include nginx role] *************************************************************************************************************
included: nginx for 134.36.5.145

TASK [nginx : Import a key for nginx] *************************************************************************************************************
ok: [134.36.5.145]

TASK [nginx : system packages | setup upstream nginx stable repo] *********************************************************************************
skipping: [134.36.5.145]

TASK [nginx : system packages | setup upstream nginx stable repo] *********************************************************************************
changed: [134.36.5.145]
```

cc @jburel @khaledk2 