### PR TITLE
Fix conditional to fix test on ansible-role-omero-web

### DIFF
--- a/tasks/redhat.yaml
+++ b/tasks/redhat.yaml
@@ -19,7 +19,7 @@
     update_cache: true
     name: "https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-{{ nginx_version }}-1.el9.ngx.x86_64.rpm"
     state: present
-  when: nginx_version
+  when: nginx_version is defined
 
 - name: system packages | install nginx
   become: true


### PR DESCRIPTION
Fixing problem in failing of the conditional check which appeared whilst testing with this role on ansible-role-omero-web:


```
TASK [ome.nginx : system packages | setup upstream nginx stable repo] **********
  Error: : Task failed: Conditional result (False) was derived from value of type 'str' at '/home/runner/.ansible/roles/ome.nginx/defaults/main.yml:5:16'. Conditionals must have a boolean result.
  Task failed.
  Origin: /home/runner/.ansible/roles/ome.nginx/tasks/redhat.yaml:16:3
  14   when: not nginx_version
  15
  16 - name: system packages | setup upstream nginx stable repo
       ^ column 3
  <<< caused by >>>
  Conditional result (False) was derived from value of type 'str' at '/home/runner/.ansible/roles/ome.nginx/defaults/main.yml:5:16'. Conditionals must have a boolean result.
  Origin: /home/runner/.ansible/roles/ome.nginx/tasks/redhat.yaml:22:9
  20     name: "[https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-{{](https://nginx.org/packages/centos/9/x86_64/RPMS/nginx-%7B%7B) nginx_version }}-1.el9.ngx.x86_64.rpm"
  21     state: present
  22   when: nginx_version
             ^ column 9
  Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.
  fatal: [omero-web-active-rockylinux9]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result (False) was derived from value of type 'str' at '/home/runner/.ansible/roles/ome.nginx/defaults/main.yml:5:16'. Conditionals must have a boolean result."
```